### PR TITLE
fix: #7 Does not work with Firefox

### DIFF
--- a/assets/ejs/assets.ejs
+++ b/assets/ejs/assets.ejs
@@ -1,6 +1,6 @@
 
 <!-- Global modal message box. -->
-<div id="NB-msg_box" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div id="NB-msg_box" class="modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header font-l font-26">


### PR DESCRIPTION
In Firefox the guest/host/free mode selection modal window is there, but because of the "fade" class.
I wasn't able to figure out why exactly this happens, but removing the "fade" class makes it work in Firefox.
